### PR TITLE
Revert "Bump addressable from 2.8.7 to 2.9.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.9.0)
-      public_suffix (>= 2.0.2, < 8.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     colorator (1.1.0)
     concurrent-ruby (1.3.4)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.17.0)
     ffi (1.17.0-x86_64-darwin)
     forwardable-extended (2.6.0)
-    google-protobuf (3.25.5)
     google-protobuf (3.25.5-x86_64-darwin)
     http_parser.rb (0.8.0)
     i18n (1.14.6)
@@ -50,22 +48,14 @@ GEM
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (7.0.5)
+    public_suffix (6.0.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.2)
     rouge (4.5.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.69.5-aarch64-linux-android)
-      google-protobuf (~> 3.23)
-    sass-embedded (1.69.5-arm-linux-androideabi)
-      google-protobuf (~> 3.23)
     sass-embedded (1.69.5-x86_64-darwin)
-      google-protobuf (~> 3.23)
-    sass-embedded (1.69.5-x86_64-linux-android)
-      google-protobuf (~> 3.23)
-    sass-embedded (1.69.5-x86_64-linux-gnu)
       google-protobuf (~> 3.23)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -74,11 +64,26 @@ GEM
 
 PLATFORMS
   aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
   arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
   x86_64-darwin
   x86_64-linux
   x86_64-linux-android
-
+  x86_64-linux-gnu
+  x86_64-linux-musl
+  
 DEPENDENCIES
   jekyll (~> 4.3.2)
   jekyll-feed


### PR DESCRIPTION
Reverts lensfun/lensfun.github.io#17